### PR TITLE
Adds syntax highlighting for multiple include blocks in terragrunt.hcl

### DIFF
--- a/grammars/terragrunt.yaml
+++ b/grammars/terragrunt.yaml
@@ -133,6 +133,27 @@ patterns:
           2: { name: keyword.operator.assignment.terragrunt }
       - include: "#definition-right"
 
+  - name: "meta.multipleinclude.terragrunt"
+    begin: '\b(include)([\w\-\"$])?(?:\s+)?(")?([^\"\n]+)?(")?(?:\s+)?({)'
+    beginCaptures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: invalid.illegal.keyword.$1.terragrunt }
+      3:
+        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      4: { name: string.quoted.double.terragrunt entity.name.$1.terragrunt }
+      5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
+      6: { name: punctuation.declaration.block.begin.terragrunt }
+    end: "}"
+    endCaptures:
+      0: { name: punctuation.declaration.block.end.terragrunt }
+    patterns:
+      - include: "#comments"
+      - match: '\b(path)(?:\s+)?(=)(?:\s+)?'
+        captures:
+          1: { name: support.output.attribute.terragrunt }
+          2: { name: keyword.operator.assignment.terragrunt }
+      - include: "#definition-right"
+
   - name: "meta.inputs.terragrunt"
     begin: '\b(inputs)([\w\-\"$])?(?:\s+)?(=)(?:\s+)?({)'
     beginCaptures:

--- a/grammars/terragrunt.yaml
+++ b/grammars/terragrunt.yaml
@@ -138,8 +138,7 @@ patterns:
     beginCaptures:
       1: { name: keyword.declaration.$1.terragrunt }
       2: { name: invalid.illegal.keyword.$1.terragrunt }
-      3:
-        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      3: { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
       4: { name: string.quoted.double.terragrunt entity.name.$1.terragrunt }
       5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
       6: { name: punctuation.declaration.block.begin.terragrunt }
@@ -152,6 +151,15 @@ patterns:
         captures:
           1: { name: support.output.attribute.terragrunt }
           2: { name: keyword.operator.assignment.terragrunt }
+      - match: '\b(expose)(?:\s+)?(=)(?:\s+)?'
+        captures:
+          1: { name: support.output.attribute.terragrunt }
+          2: { name: keyword.operator.assignment.terragrunt }
+      - match: '\b(merge_strategy)(?:\s+)?(=)(?:\s+)?'
+        captures:
+          1: { name: support.output.attribute.terragrunt }
+          2: { name: keyword.operator.assignment.terragrunt }
+
       - include: "#definition-right"
 
   - name: "meta.inputs.terragrunt"


### PR DESCRIPTION
I think this should properly capture multiple includes. I wasn't clear on what a good naming structure would be so I called the new variable `meta.multipleinclude.terragrunt` 

Related to issue #14 