### PR TITLE
Fixing syntax highlighting issues

### DIFF
--- a/examples/test-attributes.hcl
+++ b/examples/test-attributes.hcl
@@ -1,0 +1,8 @@
+terragrunt_version_constraint = "~> 0.32"
+terraform_version_constraint  = "~> 1.0"
+download_dir                  = "~/fake/dir"
+iam_role                      = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+iam_assume_role_session_name  = "sts-session-name"
+terraform_binary              = "/usr/bin/terraform_alt"
+prevent_destroy               = true
+skip                          = false

--- a/examples/test-tg-blocks.hcl
+++ b/examples/test-tg-blocks.hcl
@@ -1,0 +1,5 @@
+inputs = merge(
+  local.account_vars.locals,
+  local.region_vars.locals,
+  local.environment_vars.locals,
+)

--- a/grammars/terragrunt.yaml
+++ b/grammars/terragrunt.yaml
@@ -179,6 +179,20 @@ patterns:
           2: { name: keyword.operator.assignment.terragrunt }
       - include: "#definition-right"
 
+  - name: "meta.inputs_function.terragrunt"
+    begin: '\b(inputs)([\w\-\"$])?(?:\s+)?(=)(?:\s+)?(merge|map|tomap|zipmap)?(\()'
+    beginCaptures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: invalid.illegal.keyword.$1.terragrunt }
+      3: { name: keyword.operator.assignment.terragrunt }
+      4: { name: support.function.builtin.collection.terragrunt }
+      5: { name: punctuation.declaration.block.begin.terragrunt }
+    end: "}"
+    endCaptures:
+      0: { name: punctuation.declaration.block.end.terragrunt }
+    patterns:
+      - include: "#definition-right"
+
   - name: "meta.dependency.terragrunt"
     begin: '\b(dependency)([\w\-\"$])?(?:\s+)?(")?([^\"\n]+)?(")?(?:\s+)?({)'
     beginCaptures:
@@ -412,6 +426,80 @@ patterns:
       #   captures:
       #     1: { name: keyword.control.loop.terragrunt }
       - include: "#definition-right"
+  
+  - name: "meta.terragrunt_version_constraint.terragrunt"
+    match: '\b(terragrunt_version_constraint)(?:\s+)?(=)(?:\s+)?(")([^$"]+)?(")'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3:
+        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      4: { name: string.quoted.double.terragrunt }
+      5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
+  
+  - name: "meta.terraform_version_constraint.terragrunt"
+    match: '\b(terraform_version_constraint)(?:\s+)?(=)(?:\s+)?(")([^$"]+)?(")'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3:
+        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      4: { name: string.quoted.double.terragrunt }
+      5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
+  
+  - name: "meta.download_dir.terragrunt"
+    match: '\b(download_dir)(?:\s+)?(=)(?:\s+)?(")([^$"]+)?(")'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3:
+        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      4: { name: string.quoted.double.terragrunt }
+      5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
+  
+  - name: "meta.iam_role.terragrunt"
+    match: '\b(iam_role)(?:\s+)?(=)(?:\s+)?(")([^$"]+)?(")'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3:
+        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      4: { name: string.quoted.double.terragrunt }
+      5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
+
+  - name: "meta.iam_assume_role_session_name.terragrunt"
+    match: '\b(iam_assume_role_session_name)(?:\s+)?(=)(?:\s+)?(")([^$"]+)?(")'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3:
+        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      4: { name: string.quoted.double.terragrunt }
+      5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
+
+  - name: "meta.terraform_binary.terragrunt"
+    match: '\b(terraform_binary)(?:\s+)?(=)(?:\s+)?(")([^$"]+)?(")'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3:
+        { name: string.quoted.double.terragrunt punctuation.definition.string.begin.terragrunt }
+      4: { name: string.quoted.double.terragrunt }
+      5: { name: string.quoted.double.terragrunt punctuation.definition.string.end.terragrunt }
+
+  - name: "meta.prevent_destroy.terragrunt"
+    match: '\b(prevent_destroy)(?:\s+)?(=)(?:\s+)?(true|false)'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3: { name: constant.language.boolean.$1.terragrunt }
+  
+  - name: "meta.skip.terragrunt"
+    match: '\b(skip)(?:\s+)?(=)(?:\s+)?(true|false)'
+    captures:
+      1: { name: keyword.declaration.$1.terragrunt }
+      2: { name: keyword.operator.assignment.terragrunt }
+      3: { name: constant.language.boolean.$1.terragrunt }
 
   - include: "#invalid"
 


### PR DESCRIPTION
This resolves several, but maybe not all(?), the issues in #7. I wasn't able to reproduce all of the issues, looks like some of them may have been fixed already.

* Added support for using Terragrunt functions to generate `inputs` blocks. I only added the ones that actually return maps.
    * In theory, one could go down the rabbit hole and add support like this for all blocks, but it's probably better not to add more bloat to the grammar if nobody is actually requesting it.
* Added support for the string and boolean [standalone Terragrunt attributes](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#attributes). This includes the two requested in #7, `terraform_version_constraint` and `terragrunt_version_constraint`. 

