### PR TITLE
Fix escape character regex

### DIFF
--- a/examples/locals.tf
+++ b/examples/locals.tf
@@ -102,3 +102,9 @@ locals {
     }
   })
 }
+
+locals {
+  namespace    = trimsuffix(replace(var.namespace, "\\", "/"), "/")
+  test_escape = "\n \r \t \" \\ \u0x06 \u0x100b0f"
+  name_prefix  = "/${local.namespace}"
+}

--- a/examples/organizations.terragrunt.hcl
+++ b/examples/organizations.terragrunt.hcl
@@ -12,3 +12,9 @@ include {
 inputs = {
 
 }
+
+locals {
+  namespace    = trimsuffix(replace(var.namespace, "\\", "/"), "/")
+  test_escape = "\n \r \t \" \\ \u0x06 \u0x100b0f"
+  name_prefix  = "/${local.namespace}"
+}

--- a/grammars/terragrunt.yaml
+++ b/grammars/terragrunt.yaml
@@ -631,7 +631,11 @@ repository:
       - include: "#blocks"
 
   escape-char:
-    match: '\\\"'
+    match: '\\[nrt"\\]'
+    name: constant.character.escape.terragrunt
+  
+  escape-char-hex:
+    match: '\\u0[xX][0-9a-fA-F]+'
     name: constant.character.escape.terragrunt
 
   string-interpolation:
@@ -666,6 +670,7 @@ repository:
     name: string.template.terragrunt
     patterns:
       - include: "#escape-char"
+      - include: "#escape-char-hex"
       - match: '\$\${'
       - include: "#string-interpolation"
       - match: "%%{"

--- a/grammars/tf.yaml
+++ b/grammars/tf.yaml
@@ -458,7 +458,11 @@ repository:
       - include: "#blocks"
 
   escape-char:
-    match: '\\\"'
+    match: '\\[nrt"\\]'
+    name: constant.character.escape.tf
+  
+  escape-char-hex:
+    match: '\\u0[xX][0-9a-fA-F]+'
     name: constant.character.escape.tf
 
   string-interpolation:
@@ -493,6 +497,7 @@ repository:
     name: string.template.tf
     patterns:
       - include: "#escape-char"
+      - include: "#escape-char-hex"
       - match: '\$\${'
       - include: "#string-interpolation"
       - match: "%%{"


### PR DESCRIPTION
Fixes #10 

This PR adds support for the remaining escape characters [listed in the Terraform Documentation](https://www.terraform.io/language/expressions/strings#escape-sequences). This fix has been applied to both the Terraform and Terragrunt grammars.